### PR TITLE
When calling the `complete` callback, pass some info

### DIFF
--- a/jquery.scrollintoview.js
+++ b/jquery.scrollintoview.js
@@ -109,18 +109,24 @@
 
 				var animOptions = {};
 
+				var yDir = "none";
+
 				// vertical scroll
 				if (options.direction.y === true)
 				{
 					if (rel.top < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + rel.top;
+						yDir = "up"
 					}
 					else if (rel.top > 0 && rel.bottom < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + Math.min(rel.top, -rel.bottom);
+						yDir = "down"
 					}
 				}
+
+				var xDir = "none";
 
 				// horizontal scroll
 				if (options.direction.x === true)
@@ -128,10 +134,12 @@
 					if (rel.left < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + rel.left;
+						xDir = "left"
 					}
 					else if (rel.left > 0 && rel.right < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + Math.min(rel.left, -rel.right);
+						xDir = "right"
 					}
 				}
 
@@ -146,14 +154,14 @@
 						.animate(animOptions, options.duration)
 						.eq(0) // we want function to be called just once (ref. "html,body")
 						.queue(function (next) {
-							$.isFunction(options.complete) && options.complete.call(scroller[0]);
+							$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 							next();
 						});
 				}
 				else
 				{
 					// when there's nothing to scroll, just call the "complete" function
-					$.isFunction(options.complete) && options.complete.call(scroller[0]);
+					$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 				}
 			}
 


### PR DESCRIPTION
... about the direction we scrolled.

This is something that we need to know in our app.
(Passing this information is harmless; compatibility with
the old API is fully retained.)

   * * *

This PR is an updated version of https://github.com/litera/jquery-scrollintoview/pull/16.